### PR TITLE
Refactored Redux Store

### DIFF
--- a/src/components/AlbumContainer/enhancers/redux.ts
+++ b/src/components/AlbumContainer/enhancers/redux.ts
@@ -3,7 +3,10 @@ import { connect } from 'react-redux';
 import { Dispatch } from 'redux';
 import { AlbumQuery_album as Album } from './__generated__/AlbumQuery';
 import { startPlayingList } from '../../../redux/actions/creators/queue';
-import { getActiveQueueItemForList } from '../../../redux/selectors/nowPlaying';
+import {
+  getPlayingMatching,
+  isPlayingFromAlbum,
+} from '../../../redux/selectors/nowPlaying';
 import { State } from '../../../redux/state';
 import { getTracks } from '../../PlaybackAlbumArtwork';
 
@@ -36,10 +39,9 @@ const enhancer = connect<
   State
 >(
   (state: State, props: OwnProps): StateEnhancedProps => {
-    const activeQueueItem = getActiveQueueItemForList(
+    const activeQueueItem = getPlayingMatching(
       state.queue,
-      'ALBUM',
-      props.album.id
+      isPlayingFromAlbum(props.album.id)
     );
     if (!activeQueueItem) {
       return {};

--- a/src/components/FooterContainer/index.tsx
+++ b/src/components/FooterContainer/index.tsx
@@ -4,40 +4,20 @@ import Footer from './component';
 import { FooterQuery } from './enhancers/query';
 import { LikeMutation } from './enhancers/likeMutation';
 import { PlaySongMutation } from './enhancers/playSongMutation';
-import { Kind, QueueItem } from '../../redux/state/queue';
 import { FooterState } from './enhancers/redux';
 
 export interface InputProps {
   className: string;
 }
 
-const getIdForSourceKind = (
-  kind: Kind,
-  queueItem: QueueItem
-): string | undefined =>
-  queueItem.source && queueItem.source.kind === kind
-    ? queueItem.source.list
-    : undefined;
-
 const EnhancedFooter = ({ className }: InputProps) => (
   <FooterState>
-    {({ queueItem, nextSong, previousSong, play, pause, playing }) => (
-      <FooterQuery
-        variables={queueItem && { songId: queueItem.songId }}
-        skip={!queueItem}
-      >
+    {({ sourceMetadata, nextSong, previousSong, play, pause, playing }) => (
+      <FooterQuery variables={sourceMetadata} skip={!sourceMetadata}>
         {queryResults => (
-          <LikeMutation variables={queueItem && { songId: queueItem.songId }}>
+          <LikeMutation variables={sourceMetadata}>
             {likeCurrentSong => (
-              <PlaySongMutation
-                variables={
-                  queueItem && {
-                    songId: queueItem.songId,
-                    albumId: getIdForSourceKind('ALBUM', queueItem),
-                    artistId: getIdForSourceKind('ARTIST', queueItem),
-                  }
-                }
-              >
+              <PlaySongMutation variables={sourceMetadata}>
                 {playCurrentSong => (
                   <Footer
                     nowPlaying={queryResults.data && queryResults.data.song}

--- a/src/components/KeyboardInteraction/KeyboardInteraction.stories.tsx
+++ b/src/components/KeyboardInteraction/KeyboardInteraction.stories.tsx
@@ -13,7 +13,7 @@ storiesOf('keyboard interaction', module).add('with textfield', () => {
   store.subscribe(() => {
     const labeledAction = action('store updated');
     const state = store.getState();
-    const isPlaying = state.queue.shouldBePlaying;
+    const isPlaying = state.queue.isPlaying;
     const position = state.queue.position;
 
     labeledAction(isPlaying, position);

--- a/src/components/PlaybackAlbumArtwork.tsx
+++ b/src/components/PlaybackAlbumArtwork.tsx
@@ -3,7 +3,8 @@ import PlaybackArtwork from './PlaybackArtworkContainer';
 import { Link } from 'react-router-dom';
 import { albumPath } from '../utils/paths';
 import { AlbumArtwork } from './AlbumArtwork';
-import { Kind, QueueItemSource } from '../redux/state/queue';
+import { PlayingFromAlbum, QueueItemSource } from '../redux/state/queue';
+import { isPlayingFromAlbum } from '../redux/selectors/nowPlaying';
 
 export interface Album {
   id: string;
@@ -18,9 +19,13 @@ export interface Props {
 }
 
 export const getTracks = (album: Album): QueueItemSource[] =>
-  album.songs.map(({ id }, idx) => ({
-    songId: id,
-    source: { song: idx.toString(), list: album.id, kind: 'ALBUM' as Kind },
+  album.songs.map((song, idx) => ({
+    songId: song.id,
+    playingFrom: {
+      type: 'ALBUM',
+      albumId: album.id,
+      trackIndex: idx,
+    } as PlayingFromAlbum,
   }));
 
 export const PlaybackAlbumArtwork = ({
@@ -29,8 +34,7 @@ export const PlaybackAlbumArtwork = ({
 }: Props) => (
   <PlaybackArtwork
     backgroundInteraction={backgroundInteraction}
-    kind={'ALBUM'}
-    list={album.id}
+    checkPlayingFrom={isPlayingFromAlbum(album.id)}
     tracks={getTracks(album)}
   >
     <Link to={albumPath(album.id)}>

--- a/src/components/PlaybackArtworkContainer/index.tsx
+++ b/src/components/PlaybackArtworkContainer/index.tsx
@@ -1,20 +1,16 @@
 import React from 'react';
 
-import { Kind, QueueItemSource } from '../../redux/state/queue';
+import { QueueItemSource } from '../../redux/state/queue';
 import PlaybackArtwork from '../PlaybackArtwork';
 import { PlaybackArtworkState } from './enhancers/redux';
+import { CheckPlayingFromFn } from '../../redux/selectors/nowPlaying';
 
 export interface Props {
-  // The kind of list this is. Used to check whether the current playing
-  // item is from this list. This information also passed to onStartPlayback.
-  kind: Kind;
-
-  // The id of this list. Used to check whether the current playing item is
-  // from this list. This information is also passed to onStartPlayback.
-  list: string;
-
   // A list of tracks to enqueue when play is pressed.
   tracks: QueueItemSource[];
+
+  // Used to check whether the currently playing item is from the current list.
+  checkPlayingFrom: CheckPlayingFromFn;
 
   // See components/PlaybackArtwork.js.
   backgroundInteraction?: boolean;
@@ -24,23 +20,20 @@ export interface Props {
 
 // A connected playback artwork. It updates its state based on the current
 // playing item and calls a prop when time to play more items.
-const EnhancedComponent = ({
-  kind,
-  list,
-  tracks,
-  backgroundInteraction,
-  children,
-}: Props) => (
-  <PlaybackArtworkState kind={kind} list={list} tracks={tracks}>
+const EnhancedComponent = (props: Props) => (
+  <PlaybackArtworkState
+    checkPlayingFrom={props.checkPlayingFrom}
+    tracks={props.tracks}
+  >
     {({ state, onPlaying, onPaused, onStartPlayback }) => (
       <PlaybackArtwork
         state={state}
         onPlaying={onPlaying}
         onPaused={onPaused}
         onStartPlayback={onStartPlayback}
-        backgroundInteraction={backgroundInteraction}
+        backgroundInteraction={props.backgroundInteraction}
       >
-        {children}
+        {props.children}
       </PlaybackArtwork>
     )}
   </PlaybackArtworkState>

--- a/src/components/QueueContainer/enhancers/redux.ts
+++ b/src/components/QueueContainer/enhancers/redux.ts
@@ -44,7 +44,11 @@ const enhancer = connect<
       dispatch(skipToPosition(position));
     },
   }),
-  (stateProps, actionProps, ownProps) => ({
+  (
+    stateProps: StateEnhancedProps,
+    actionProps: ActionEnhancedProps,
+    ownProps: OwnProps
+  ) => ({
     ...stateProps,
     ...actionProps,
     ...ownProps,

--- a/src/components/SongsContainer/enhancers/redux.tsx
+++ b/src/components/SongsContainer/enhancers/redux.tsx
@@ -2,9 +2,12 @@ import React from 'react';
 import { Dispatch } from 'redux';
 import { connect } from 'react-redux';
 import { State } from '../../../redux/state';
-import { getActiveQueueItemForList } from '../../../redux/selectors/nowPlaying';
+import {
+  getPlayingMatching,
+  isPlayingFromSongs,
+} from '../../../redux/selectors/nowPlaying';
 import { startPlayingList } from '../../../redux/actions/creators/queue';
-import { Kind, QueueItemSource } from '../../../redux/state/queue';
+import { PlayingFromSongs, QueueItemSource } from '../../../redux/state/queue';
 
 interface StateEnhancedProps {
   activeSongId?: string;
@@ -30,7 +33,10 @@ interface OwnProps {
 interface MergedProps extends ChildProps, OwnProps {}
 
 const getTracks = (songs: Song[]): QueueItemSource[] =>
-  songs.map(song => ({ songId: song.id, source: { kind: 'SONGS' as Kind } }));
+  songs.map(song => ({
+    songId: song.id,
+    playingFrom: { type: 'SONGS' } as PlayingFromSongs,
+  }));
 
 const enhancer = connect<
   StateEnhancedProps,
@@ -40,11 +46,7 @@ const enhancer = connect<
   State
 >(
   (state: State): StateEnhancedProps => {
-    const activeQueueItem = getActiveQueueItemForList(
-      state.queue,
-      'SONGS',
-      undefined
-    );
+    const activeQueueItem = getPlayingMatching(state.queue, isPlayingFromSongs);
 
     if (!activeQueueItem) {
       return {};

--- a/src/redux/reducers/__snapshots__/queue.test.ts.snap
+++ b/src/redux/reducers/__snapshots__/queue.test.ts.snap
@@ -2,195 +2,228 @@
 
 exports[`add to queue reducer adds after current playing item 1`] = `
 Object {
+  "isPlaying": false,
   "items": Array [
     Object {
       "id": "a",
+      "playingFrom": Object {},
       "songId": "Legend",
     },
     Object {
       "id": "b",
+      "playingFrom": Object {},
       "songId": "Blessings (Explicit) ft. Drake, Kanye West",
     },
     Object {
       "id": "c",
+      "playingFrom": Object {},
       "songId": "Pick Me Up ft. Anna of the North",
     },
     Object {
       "id": "2",
+      "playingFrom": Object {},
       "songId": "this is a song",
     },
     Object {
       "id": "3",
+      "playingFrom": Object {},
       "songId": "this is another song",
     },
     Object {
       "id": "d",
+      "playingFrom": Object {},
       "songId": "No Less",
     },
     Object {
       "id": "e",
+      "playingFrom": Object {},
       "songId": "Love Is Gone (Audio) ft. Drew Love (of THEY.)",
     },
   ],
   "position": 2,
-  "shouldBePlaying": false,
 }
 `;
 
 exports[`add to queue reducer adds before current playing item 1`] = `
 Object {
+  "isPlaying": false,
   "items": Array [
     Object {
       "id": "a",
+      "playingFrom": Object {},
       "songId": "Legend",
     },
     Object {
       "id": "4",
+      "playingFrom": Object {},
       "songId": "this is a song",
     },
     Object {
       "id": "5",
+      "playingFrom": Object {},
       "songId": "this is another song",
     },
     Object {
       "id": "b",
+      "playingFrom": Object {},
       "songId": "Blessings (Explicit) ft. Drake, Kanye West",
     },
     Object {
       "id": "c",
+      "playingFrom": Object {},
       "songId": "Pick Me Up ft. Anna of the North",
     },
     Object {
       "id": "d",
+      "playingFrom": Object {},
       "songId": "No Less",
     },
     Object {
       "id": "e",
+      "playingFrom": Object {},
       "songId": "Love Is Gone (Audio) ft. Drew Love (of THEY.)",
     },
   ],
   "position": 2,
-  "shouldBePlaying": false,
 }
 `;
 
 exports[`add to queue reducer adds to end of queue 1`] = `
 Object {
+  "isPlaying": false,
   "items": Array [
     Object {
       "id": "a",
+      "playingFrom": Object {},
       "songId": "Legend",
     },
     Object {
       "id": "b",
+      "playingFrom": Object {},
       "songId": "Blessings (Explicit) ft. Drake, Kanye West",
     },
     Object {
       "id": "c",
+      "playingFrom": Object {},
       "songId": "Pick Me Up ft. Anna of the North",
     },
     Object {
       "id": "d",
+      "playingFrom": Object {},
       "songId": "No Less",
     },
     Object {
       "id": "e",
+      "playingFrom": Object {},
       "songId": "Love Is Gone (Audio) ft. Drew Love (of THEY.)",
     },
     Object {
       "id": "0",
+      "playingFrom": Object {},
       "songId": "this is a song",
     },
     Object {
       "id": "1",
+      "playingFrom": Object {},
       "songId": "this is another song",
     },
   ],
   "position": 2,
-  "shouldBePlaying": false,
 }
 `;
 
 exports[`remove reducer removes songs after the current playing song 1`] = `
 Object {
+  "isPlaying": false,
   "items": Array [
     Object {
       "id": "a",
+      "playingFrom": Object {},
       "songId": "Legend",
     },
     Object {
       "id": "b",
+      "playingFrom": Object {},
       "songId": "Blessings (Explicit) ft. Drake, Kanye West",
     },
     Object {
       "id": "c",
+      "playingFrom": Object {},
       "songId": "Pick Me Up ft. Anna of the North",
     },
   ],
   "position": 2,
-  "shouldBePlaying": false,
 }
 `;
 
 exports[`remove reducer removes songs before the current playing song 1`] = `
 Object {
+  "isPlaying": false,
   "items": Array [
     Object {
       "id": "c",
+      "playingFrom": Object {},
       "songId": "Pick Me Up ft. Anna of the North",
     },
     Object {
       "id": "d",
+      "playingFrom": Object {},
       "songId": "No Less",
     },
     Object {
       "id": "e",
+      "playingFrom": Object {},
       "songId": "Love Is Gone (Audio) ft. Drew Love (of THEY.)",
     },
   ],
   "position": 0,
-  "shouldBePlaying": false,
 }
 `;
 
 exports[`remove reducer removes the currently playing song 1`] = `
 Object {
+  "isPlaying": false,
   "items": Array [
     Object {
       "id": "a",
+      "playingFrom": Object {},
       "songId": "Legend",
     },
     Object {
       "id": "b",
+      "playingFrom": Object {},
       "songId": "Blessings (Explicit) ft. Drake, Kanye West",
     },
     Object {
       "id": "d",
+      "playingFrom": Object {},
       "songId": "No Less",
     },
     Object {
       "id": "e",
+      "playingFrom": Object {},
       "songId": "Love Is Gone (Audio) ft. Drew Love (of THEY.)",
     },
   ],
   "position": 2,
-  "shouldBePlaying": false,
 }
 `;
 
 exports[`replace reducer replaces the queue 1`] = `
 Object {
+  "isPlaying": false,
   "items": Array [
     Object {
       "id": "6",
+      "playingFrom": Object {},
       "songId": "Just The Way You Are",
     },
     Object {
       "id": "7",
+      "playingFrom": Object {},
       "songId": "Glad You Came",
     },
   ],
   "position": 0,
-  "shouldBePlaying": false,
 }
 `;

--- a/src/redux/reducers/queue.test.ts
+++ b/src/redux/reducers/queue.test.ts
@@ -18,23 +18,36 @@ import {
   SkipPositionAction,
   SkipRelativeAction,
 } from '../actions';
+import { emptyPlayingFrom } from '../../utils/populateQueue';
 
 const initialState = {
   items: [
-    { id: 'a', songId: 'Legend' },
-    { id: 'b', songId: 'Blessings (Explicit) ft. Drake, Kanye West' },
-    { id: 'c', songId: 'Pick Me Up ft. Anna of the North' },
-    { id: 'd', songId: 'No Less' },
-    { id: 'e', songId: 'Love Is Gone (Audio) ft. Drew Love (of THEY.)' },
+    { id: 'a', songId: 'Legend', playingFrom: emptyPlayingFrom },
+    {
+      id: 'b',
+      songId: 'Blessings (Explicit) ft. Drake, Kanye West',
+      playingFrom: emptyPlayingFrom,
+    },
+    {
+      id: 'c',
+      songId: 'Pick Me Up ft. Anna of the North',
+      playingFrom: emptyPlayingFrom,
+    },
+    { id: 'd', songId: 'No Less', playingFrom: emptyPlayingFrom },
+    {
+      id: 'e',
+      songId: 'Love Is Gone (Audio) ft. Drew Love (of THEY.)',
+      playingFrom: emptyPlayingFrom,
+    },
   ],
   position: 2,
-  shouldBePlaying: false,
+  isPlaying: false,
 };
 
 describe('add to queue reducer', () => {
   const items = [
-    { songId: 'this is a song' },
-    { songId: 'this is another song' },
+    { songId: 'this is a song', playingFrom: emptyPlayingFrom },
+    { songId: 'this is another song', playingFrom: emptyPlayingFrom },
   ];
 
   it('adds to end of queue', () => {
@@ -72,7 +85,10 @@ describe('replace reducer', () => {
   it('replaces the queue', () => {
     const action: ReplaceQueueAction = {
       type: 'REPLACE_QUEUE',
-      items: [{ songId: 'Just The Way You Are' }, { songId: 'Glad You Came' }],
+      items: [
+        { songId: 'Just The Way You Are', playingFrom: emptyPlayingFrom },
+        { songId: 'Glad You Came', playingFrom: emptyPlayingFrom },
+      ],
     };
     const newState = replaceQueue(initialState, action);
     expect(newState).toMatchSnapshot();
@@ -173,19 +189,19 @@ describe('set playback reducer', () => {
   it('sets playing to true', () => {
     const action: SetPlaybackAction = { type: 'SET_PLAYBACK', playing: true };
     const newState = setPlayback(initialState, action);
-    expect(newState).toEqual({ ...initialState, shouldBePlaying: true });
+    expect(newState).toEqual({ ...initialState, isPlaying: true });
   });
 });
 
 describe('toggle playback reducer', () => {
   it('changes from paused to playing', () => {
     const newState = togglePlayback(initialState);
-    expect(newState.shouldBePlaying).toEqual(true);
+    expect(newState.isPlaying).toEqual(true);
   });
 
   it('changes from playing to paused', () => {
-    const localState = { ...initialState, shouldBePlaying: true };
+    const localState = { ...initialState, isPlaying: true };
     const newState = togglePlayback(localState);
-    expect(newState.shouldBePlaying).toEqual(false);
+    expect(newState.isPlaying).toEqual(false);
   });
 });

--- a/src/redux/reducers/queue.ts
+++ b/src/redux/reducers/queue.ts
@@ -164,12 +164,11 @@ export const setPlayback = (
 ): QueueState => {
   const { playing } = action;
 
-  return { ...state, shouldBePlaying: playing };
+  return { ...state, isPlaying: playing };
 };
 
 export const togglePlayback = (state: QueueState): QueueState => {
-  const { shouldBePlaying } = state;
-  return { ...state, shouldBePlaying: !shouldBePlaying };
+  return { ...state, isPlaying: !state.isPlaying };
 };
 
 const bounded = (num: number, lower: number, upper: number): number => {

--- a/src/redux/selectors/nowPlaying.ts
+++ b/src/redux/selectors/nowPlaying.ts
@@ -1,38 +1,39 @@
-import { Kind, QueueItem, QueueState, Source } from '../state/queue';
+import { PlayingFrom, QueueItem, QueueState } from '../state/queue';
 
-export const nowPlaying = ({
-  items,
-  position,
-}: QueueState): QueueItem | undefined => items[position];
-
-// Checks whether the list of kind with identifier list is the same as source.
-export const isSource = (source: Source, kind: Kind, list?: string): boolean =>
-  source.kind === kind && source.list === list;
-
-// Gets the QueueItem of the currently playing item if it has the kind and
-// list id specified. Otherwise returns void signifying that the list isn't
-// currently playing.
-export const getActiveQueueItemForList = (
+// Gets the QueueItem of the currently playing if there is an item currently
+// playing and the currently playing queue item's playingFrom passes the
+// checkPlayingFrom function.
+export const getPlayingMatching = (
   queue: QueueState,
-  kind: Kind,
-  listId?: string
-): QueueItem | void => {
+  checkPlayingFrom: CheckPlayingFromFn
+): QueueItem | undefined => {
   const queueItem = nowPlaying(queue);
   if (!queueItem) {
     // Nothing is playing.
     return;
   }
 
-  if (!queueItem.source) {
-    // Something is playing but no information about its origin is attached
-    // to it.
-    return;
-  }
-
-  if (!isSource(queueItem.source, kind, listId)) {
-    // There is something playing but it isn't from the provided list.
+  if (!checkPlayingFrom(queueItem.playingFrom)) {
+    // Failed check.
     return;
   }
 
   return queueItem;
 };
+
+export type CheckPlayingFromFn = (playingFrom: PlayingFrom) => boolean;
+
+export const isPlayingFromAlbum = (albumId: string): CheckPlayingFromFn => (
+  playingFrom: PlayingFrom
+) => playingFrom.type === 'ALBUM' && playingFrom.albumId === albumId;
+
+export const isPlayingFromArtist = (artistId: string): CheckPlayingFromFn => (
+  playingFrom: PlayingFrom
+) => playingFrom.type === 'ARTIST' && playingFrom.artistId === artistId;
+
+export const isPlayingFromSongs: CheckPlayingFromFn = (
+  playingFrom: PlayingFrom
+) => playingFrom.type === 'SONGS';
+
+export const nowPlaying = (queue: QueueState): QueueItem | undefined =>
+  queue.items[queue.position];

--- a/src/redux/state/queue.ts
+++ b/src/redux/state/queue.ts
@@ -1,38 +1,3 @@
-export type ID = string;
-
-export type Kind = 'PLAYLIST' | 'ALBUM' | 'ARTIST' | 'SONGS';
-
-// A collection of information about where a song was queued from.
-export interface Source {
-  // An opaque string identifying the source list (playlist, album's tracks,
-  // artist's songs) from which a song is being played.
-  list?: string;
-
-  // The kind of list the song was created from.
-  kind?: Kind;
-
-  // An opaque string identifying an item in the source list. If a
-  // listSource is specified, a songSource may be specified. For
-  // example, for playlists, this could be PlaylistItem.id, for albums this
-  // might not be specified because a song id can only occur once in an album.
-  song?: string;
-}
-
-export interface QueueItemSource {
-  // The id of the song to play. Full information about this song can be
-  // resolved by querying the graphql API.
-  songId: string;
-
-  source?: Source;
-}
-
-export type QueueItem = {
-  // A cursor used to identify a specific item in a queue. The index wasn't used
-  // used because it varies based on position. The song id wasn't used because
-  // it could appear multiple times in a queue.
-  id: ID;
-} & QueueItemSource;
-
 // State to represent a queue of songs.
 export interface QueueState {
   // A list of songs.
@@ -44,14 +9,52 @@ export interface QueueState {
 
   // The state playback should be in. This is passed to the audio element
   // responsible for downloading and playing songs.
-  shouldBePlaying: boolean;
+  isPlaying: boolean;
+}
+
+export interface QueueItem extends QueueItemSource {
+  // A cursor used to identify a specific item in a queue.
+  id: ID;
+}
+
+// Input type to many action creators. An identifier is created and assigned
+// by reducers.
+export interface QueueItemSource {
+  // The id of the song to play.
+  songId: string;
+
+  playingFrom: PlayingFrom;
+}
+
+// Information about where a queue item is playing from.
+export type PlayingFrom =
+  | PlayingFromAlbum
+  | PlayingFromArtist
+  | PlayingFromSongs;
+
+// Information about which a queue item from an album is playing from.
+export interface PlayingFromAlbum {
+  type: 'ALBUM';
+  albumId: string;
+  trackIndex: number;
+}
+
+// Information about where a queue item from an artist is playing from.
+export interface PlayingFromArtist {
+  type: 'ARTIST';
+  artistId: string;
+}
+
+export interface PlayingFromSongs {
+  type: 'SONGS';
 }
 
 export const initialState: QueueState = {
   items: [],
   position: 0,
-  shouldBePlaying: false,
+  isPlaying: false,
 };
 
+export type ID = string;
 let lastId = 0;
 export const getId = (): ID => String(lastId++);

--- a/src/utils/populateQueue.ts
+++ b/src/utils/populateQueue.ts
@@ -1,11 +1,15 @@
 import { songs } from '@forte-music/mock/models';
 import { replaceQueue } from '../redux/actions';
+import { PlayingFrom } from '../redux/state/queue';
+
+export const emptyPlayingFrom: PlayingFrom = {} as PlayingFrom;
 
 const ids = Array.from(songs.keys());
 ids.sort();
 
 const itemSources = new Array(1000).fill(undefined).map((_, idx) => ({
   songId: ids[idx % ids.length],
+  playingFrom: emptyPlayingFrom,
 }));
 
 // An action creator to populate the queue with many items.


### PR DESCRIPTION
A few things were changed.

* shouldBePlaying -> isPlaying. This is the source of truth for whether
something should be playing.

* Strongly typed information about where queue items were created from.
This allows for reporting playback information and showing now playing
indicators in the correct places.

* Pulled logic for a couple of components up to redux container. The
presentational components should be doing very little work.